### PR TITLE
GM-144 토큰 예외 메세지 변경

### DIFF
--- a/src/main/java/com/gaaji/apigateway/exception/AccessTokenExpiredException.java
+++ b/src/main/java/com/gaaji/apigateway/exception/AccessTokenExpiredException.java
@@ -2,9 +2,9 @@ package com.gaaji.apigateway.exception;
 
 import static com.gaaji.apigateway.exception.GatewayErrorCode.ACCESS_TOKEN_EXPIRED;
 
-public class TokenExpiredException extends AbstractApiException{
+public class AccessTokenExpiredException extends AbstractApiException{
 
-    public TokenExpiredException() {
+    public AccessTokenExpiredException() {
         super(ACCESS_TOKEN_EXPIRED);
     }
 }

--- a/src/main/java/com/gaaji/apigateway/exception/AccessTokenInvalidException.java
+++ b/src/main/java/com/gaaji/apigateway/exception/AccessTokenInvalidException.java
@@ -2,9 +2,9 @@ package com.gaaji.apigateway.exception;
 
 import static com.gaaji.apigateway.exception.GatewayErrorCode.ACCESS_TOKEN_INVALID;
 
-public class TokenInvalidException extends AbstractApiException{
+public class AccessTokenInvalidException extends AbstractApiException{
 
-    public TokenInvalidException() {
+    public AccessTokenInvalidException() {
         super(ACCESS_TOKEN_INVALID);
     }
 }

--- a/src/main/java/com/gaaji/apigateway/exception/GatewayErrorCode.java
+++ b/src/main/java/com/gaaji/apigateway/exception/GatewayErrorCode.java
@@ -18,10 +18,15 @@ public enum GatewayErrorCode implements ErrorCode{
     ACCESS_TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "G-0002",
             "로그인 후 이용해주세요."),
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "G-0003",
-            "토큰이 만료되었습니다."),
+            "엑세스 토큰이 만료되었습니다."),
     ACCESS_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "G-0004",
-            "토큰이 유효하지 않습니다."),
-
+            "엑세스 토큰이 유효하지 않습니다."),
+    TOWN_TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "G-0005",
+            "동네 토큰이 존재하지 않습니다."),
+    TOWN_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "G-0006",
+            "동네 토큰이 만료되었습니다."),
+    TOWN_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "G-0007",
+            "동네 토큰이 유효하지 않습니다."),
 
     ;
 

--- a/src/main/java/com/gaaji/apigateway/exception/TownTokenExpiredException.java
+++ b/src/main/java/com/gaaji/apigateway/exception/TownTokenExpiredException.java
@@ -1,0 +1,10 @@
+package com.gaaji.apigateway.exception;
+
+import static com.gaaji.apigateway.exception.GatewayErrorCode.TOWN_TOKEN_EXPIRED;
+
+public class TownTokenExpiredException extends AbstractApiException{
+
+    public TownTokenExpiredException() {
+        super(TOWN_TOKEN_EXPIRED);
+    }
+}

--- a/src/main/java/com/gaaji/apigateway/exception/TownTokenInvalidException.java
+++ b/src/main/java/com/gaaji/apigateway/exception/TownTokenInvalidException.java
@@ -1,0 +1,10 @@
+package com.gaaji.apigateway.exception;
+
+import static com.gaaji.apigateway.exception.GatewayErrorCode.TOWN_TOKEN_INVALID;
+
+public class TownTokenInvalidException extends AbstractApiException{
+
+    public TownTokenInvalidException() {
+        super(TOWN_TOKEN_INVALID);
+    }
+}

--- a/src/main/java/com/gaaji/apigateway/exception/TownTokenMissingException.java
+++ b/src/main/java/com/gaaji/apigateway/exception/TownTokenMissingException.java
@@ -1,0 +1,10 @@
+package com.gaaji.apigateway.exception;
+
+import static com.gaaji.apigateway.exception.GatewayErrorCode.TOWN_TOKEN_MISSING;
+
+public class TownTokenMissingException extends AbstractApiException{
+
+    public TownTokenMissingException() {
+        super(TOWN_TOKEN_MISSING);
+    }
+}

--- a/src/main/java/com/gaaji/apigateway/filter/AuthorizationParsingFilter.java
+++ b/src/main/java/com/gaaji/apigateway/filter/AuthorizationParsingFilter.java
@@ -1,7 +1,7 @@
 package com.gaaji.apigateway.filter;
 
-import com.gaaji.apigateway.exception.TokenExpiredException;
-import com.gaaji.apigateway.exception.TokenInvalidException;
+import com.gaaji.apigateway.exception.AccessTokenExpiredException;
+import com.gaaji.apigateway.exception.AccessTokenInvalidException;
 import com.gaaji.apigateway.exception.AccessTokenMissingException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -63,11 +63,11 @@ public class AuthorizationParsingFilter extends AbstractGatewayFilterFactory<Aut
                 .parseClaimsJws(token).getBody();
 
         if (!claims.getExpiration().after(new Date())) {
-            throw new TokenExpiredException();
+            throw new AccessTokenExpiredException();
         }
 
         if (!StringUtils.hasText(claims.getSubject())) {
-            throw new TokenInvalidException();
+            throw new AccessTokenInvalidException();
         }
 
         return claims.getSubject();

--- a/src/main/java/com/gaaji/apigateway/filter/TownTokenParsingFilter.java
+++ b/src/main/java/com/gaaji/apigateway/filter/TownTokenParsingFilter.java
@@ -1,21 +1,19 @@
 package com.gaaji.apigateway.filter;
 
-import com.gaaji.apigateway.exception.TokenExpiredException;
-import com.gaaji.apigateway.exception.TokenInvalidException;
-import com.gaaji.apigateway.exception.AccessTokenMissingException;
+import com.gaaji.apigateway.exception.TownTokenExpiredException;
+import com.gaaji.apigateway.exception.TownTokenInvalidException;
+import com.gaaji.apigateway.exception.TownTokenMissingException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Date;
-import java.util.List;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.core.env.Environment;
 import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.http.server.reactive.ServerHttpRequest.Builder;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -43,7 +41,7 @@ public class TownTokenParsingFilter extends
             ServerHttpResponse response = exchange.getResponse();
 
             if (!request.getHeaders().containsKey("X-TOWN-TOKEN")) {
-                throw new AccessTokenMissingException();
+                throw new TownTokenMissingException();
             }
 
             String townToken = request.getHeaders().get("X-TOWN-TOKEN").get(0);
@@ -66,11 +64,11 @@ public class TownTokenParsingFilter extends
                 .parseClaimsJws(token).getBody();
 
         if (!claims.getExpiration().after(new Date())) {
-            throw new TokenExpiredException();
+            throw new TownTokenExpiredException();
         }
 
         if (!StringUtils.hasText(claims.getSubject())) {
-            throw new TokenInvalidException();
+            throw new TownTokenInvalidException();
         }
 
         return claims.getSubject();


### PR DESCRIPTION
# GM#144 - 토큰 예외 메세지 변경
## Description
> 엑세스 토큰과 동네 토큰의 예외 메세지가 같은 것을 변경하였다.

## PR Type
- [ ] Hotfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Issues
토큰 관련 예외가 발생했을 때, 엑세스 토큰과 동네 토큰 중 어디서 발생했는지 추적할 수 없어서 둘의 예외를 분리하였다.
```java
    UNHANDLED_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G-0001",
            "현재 해당 서비스가 정상 가동하기 힘든 상태입니다. "
                    + "오류 발생 상황과 오류 코드를 관리자 이메일로 "
                    + "전송해주시면 빠르게 조치하겠습니다."),

    ACCESS_TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "G-0002",
            "로그인 후 이용해주세요."),
    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "G-0003",
            "엑세스 토큰이 만료되었습니다."),
    ACCESS_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "G-0004",
            "엑세스 토큰이 유효하지 않습니다."),
    TOWN_TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "G-0005",
            "동네 토큰이 존재하지 않습니다."),
    TOWN_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "G-0006",
            "동네 토큰이 만료되었습니다."),
    TOWN_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "G-0007",
            "동네 토큰이 유효하지 않습니다."),

    ;
```
## Related Files
- `AuthorizationParsingFilter`
- `TownTokenParsingFilter`
- `GatewayErrorCode`

## Think About..  
추후에 도커 만들어서 배포하겠슴다

